### PR TITLE
[ANDDOX-11145] reverted to using local library for sample app build

### DIFF
--- a/CallWithDoxDialerSample/build.gradle.kts
+++ b/CallWithDoxDialerSample/build.gradle.kts
@@ -56,8 +56,8 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     // Import CallWithDoxDialerLib as a local module to test new features
-    // implementation(project(":CallWithDoxDialerLib"))
+    implementation(project(":CallWithDoxDialerLib"))
 
     // You can also import CallWithDoxDialerLib directly from GitHub
-    implementation("com.github.doximity:android-dialer-call-lib:v2.0.0")
+    // implementation("com.github.doximity:android-dialer-call-lib:v2.0.0")
 }


### PR DESCRIPTION
Due to issues deploying to jitpack, the sample app is now pointing to the local library rather than to the published library.