### PR TITLE
[ANDDOX-11145] updated to 2.0.1 to solve jitpack deployment issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0] - 2025-11-10
+## [2.0.1] - 2025-11-10
 
 ### Added
 - New `startVoiceCall()` function to immediately initiate a voice call through Doximity Dialer
@@ -65,8 +65,8 @@ All notable changes to this project will be documented in this file.
 - Sample app demonstrating library usage
 - Support for Android API 19+
 
-[Unreleased]: https://github.com/doximity/android-dialer-call-lib/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/doximity/android-dialer-call-lib/compare/v1.1.1...v2.0.0
+[Unreleased]: https://github.com/doximity/android-dialer-call-lib/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/doximity/android-dialer-call-lib/compare/v1.1.1...v2.0.1
 [1.1.1]: https://github.com/doximity/android-dialer-call-lib/compare/v1.1...v1.1.1
 [1.1.0]: https://github.com/doximity/android-dialer-call-lib/compare/v1.0...v1.1
 [1.0.0]: https://github.com/doximity/android-dialer-call-lib/releases/tag/v1.0

--- a/CallWithDoxDialerLib/build.gradle.kts
+++ b/CallWithDoxDialerLib/build.gradle.kts
@@ -36,11 +36,11 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("release") {
-                version = "2.0.0"
+                version = "2.0.1"
                 from(components["release"])
             }
             create<MavenPublication>("debug") {
-                version = "2.0.0"
+                version = "2.0.1"
                 from(components["debug"])
             }
         }

--- a/CallWithDoxDialerSample/build.gradle.kts
+++ b/CallWithDoxDialerSample/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         minSdk = 21
         targetSdk = 35
         versionCode = 3
-        versionName = "2.0.0"
+        versionName = "2.0.1"
     }
 
     buildTypes {
@@ -56,8 +56,8 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     // Import CallWithDoxDialerLib as a local module to test new features
-    implementation(project(":CallWithDoxDialerLib"))
+//    implementation(project(":CallWithDoxDialerLib"))
 
     // You can also import CallWithDoxDialerLib directly from GitHub
-    // implementation("com.github.doximity:android-dialer-call-lib:v2.0.0")
+    implementation("com.github.doximity:android-dialer-call-lib:v2.0.1")
 }


### PR DESCRIPTION
Had to move on from 2.0.0 after a failed deployment to jitpack with that tag. Now that 2.0.1 is deployed there, switched the default sample library dependency back to the published library from the local version.